### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "picomatch": "^2.3.2",
     "flatted": "^3.4.2",
     "minimatch": "^9.0.7",
-    "fast-uri": ">=3.1.2"
+    "fast-uri": "^3.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "handlebars": "^4.7.9",
     "picomatch": "^2.3.2",
     "flatted": "^3.4.2",
-    "minimatch": "^9.0.7"
+    "minimatch": "^9.0.7",
+    "fast-uri": ">=3.1.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -562,7 +562,7 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
-fast-uri@>=3.1.2, fast-uri@^3.0.1:
+fast-uri@^3.1.2, fast-uri@^3.0.1:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
   integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -562,10 +562,10 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
-fast-uri@^3.0.1:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.0.tgz#66eecff6c764c0df9b762e62ca7edcfb53b4edfa"
-  integrity sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==
+fast-uri@>=3.1.2, fast-uri@^3.0.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
+  integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
 
 fastq@^1.6.0:
   version "1.20.1"


### PR DESCRIPTION
## Summary

- Bumped `fast-uri` to 3.1.2 via yarn resolution to resolve two high-severity vulnerabilities

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #45 | `fast-uri` | **high** | Added `fast-uri: >=3.1.2` to yarn resolutions |
| #44 | `fast-uri` | **high** | Added `fast-uri: >=3.1.2` to yarn resolutions |

`fast-uri` is a transitive dependency pulled in via `ajv`. Both alerts are resolved by the single resolution entry.