### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "picomatch": "^2.3.2",
     "flatted": "^3.4.2",
     "minimatch": "^9.0.7",
-    "fast-uri": "^3.1.2"
+    "fast-uri": "^3.1.4",
+    "js-yaml": "^4.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -562,10 +562,10 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
-fast-uri@^3.1.2, fast-uri@^3.0.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
-  integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
+fast-uri@^3.0.1, fast-uri@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.4.tgz#3b3daf9ce68f41f956df0b505132c0cfce9ec7af"
+  integrity sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==
 
 fastq@^1.6.0:
   version "1.20.1"
@@ -757,10 +757,10 @@ isobject@^2.0.0:
   dependencies:
     isarray "1.0.0"
 
-js-yaml@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
-  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
+js-yaml@^4.1.0, js-yaml@^4.2.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
+  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
## Summary

- Resolved 3 open Dependabot security alerts by bumping vulnerable transitive dependencies via yarn `resolutions`

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #49 | `fast-uri` | **high** | Bumped resolution to `^3.1.4` (host confusion via literal backslash authority delimiter) |
| #48 | `fast-uri` | **high** | Bumped resolution to `^3.1.4` (host confusion via failed IDN canonicalization) |
| #47 | `js-yaml` | **medium** | Added resolution `^4.2.0` (quadratic-complexity DoS in merge key handling) |

## Test plan

- [x] `yarn install` regenerates `yarn.lock` with patched versions of `fast-uri` (3.1.4) and `js-yaml` (4.3.0)
- [x] `yarn test` passes (52/52 tests)