### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "flatted": "^3.4.2",
     "minimatch": "^9.0.7",
     "fast-uri": "^3.1.4",
-    "js-yaml": "^4.2.0"
+    "js-yaml": "^4.2.0",
+    "brace-expansion": "^2.1.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -337,10 +337,10 @@ binaryen@102.0.0-nightly.20211028:
   resolved "https://registry.yarnpkg.com/binaryen/-/binaryen-102.0.0-nightly.20211028.tgz#8f1efb0920afd34509e342e37f84313ec936afb2"
   integrity sha512-GCJBVB5exbxzzvyt8MGDv/MeUjs6gkXDvf4xOIItRBptYl0Tz5sm1o/uG95YK0L0VeG5ajDu3hRtkBP2kzqC5w==
 
-brace-expansion@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.3.tgz#0493338bdd58e319b1039c67cf7ee439892c01d9"
-  integrity sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==
+brace-expansion@^2.0.2, brace-expansion@^2.1.2:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.4.tgz#589dab11c0018d0366be64cd8bf12c8dbecc8326"
+  integrity sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==
   dependencies:
     balanced-match "^1.0.0"
 


### PR DESCRIPTION
## Summary

- Bumped `brace-expansion` to `2.1.4` via yarn resolution to fix high-severity DoS vulnerability (alert #50)

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #50 | `brace-expansion` | **high** | Added `"brace-expansion": "^2.1.2"` to `resolutions` in `package.json`; resolves to 2.1.4 |

**Vulnerability:** brace-expansion DoS via exponential-time expansion of consecutive non-expanding `{}` groups (vulnerable range `>= 2.0.0, < 2.1.2`)