### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "flatted": "^3.4.2",
     "minimatch": "^9.0.7",
     "fast-uri": "^3.1.5",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.1",
     "brace-expansion": "^2.1.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -757,10 +757,10 @@ isobject@^2.0.0:
   dependencies:
     isarray "1.0.0"
 
-js-yaml@^4.1.0, js-yaml@^4.2.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
-  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
+js-yaml@^4.1.0, js-yaml@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.1.tgz#01216c001d67f48e2cd560d708c7af21090a3848"
+  integrity sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
## Summary

- Bumped `js-yaml` to 4.3.1 via the `resolutions` field to resolve a high severity vulnerability (quadratic CPU consumption in `!!omap` resolution)

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #54 | `js-yaml` | **high** | Bumped to 4.3.1 via yarn resolution |